### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,5 @@
     "test": "node test.js"
   },
   "repository": "http://github.com/isaacs/abbrev-js",
-  "license": {
-    "type": "MIT",
-    "url": "https://github.com/isaacs/abbrev-js/raw/master/LICENSE"
-  }
+  "license": "MIT"
 }


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/